### PR TITLE
AD-HOC fix (Dependencies): Add libssl-dev to deps

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -7,4 +7,5 @@
     # python is python2
     - "python"
     - "python-pip"
+    - "libssl-dev"
     - "libcurl4-openssl-dev"


### PR DESCRIPTION
During the deployment of this role, it was discovered some ubuntu
environments do not include the package "libssl-dev". This commit adds
it to the noted dependencies.