### PR TITLE
AD-HOC feat (server-task): add variable to set required version or de…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,6 @@
 ##
 ## (Optional)
 # thumbor_auto_webp: "False"
+
+## Whether specific version of thumbor should be installed (defaults to latest if not set)
+# thumbor_version: "6.5.1"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -11,11 +11,20 @@
     group: "thumbor"
     system: "yes"
 
-- name: "Ensure thumbor application is present"
+- name: "Ensure latest version of thumbor application is present"
+  pip:
+    executable: "pip2"
+    name: "thumbor"
+    state: "latest"
+  when: (thumbor_version is undefined)
+
+- name: "Ensure specific version of thumbor application is present"
   pip:
     executable: "pip2"
     name: "thumbor"
     state: "present"
+    version: "{{ thumbor_version }}"
+  when: (thumbor_version is defined)
 
 - name: "Enforce the thumbor configuration directory"
   file:


### PR DESCRIPTION
…fault to latest

      Currently the role installs thumbor using pip and once it is installed there is no mechanism for updating to a newer
      version (the task requires it to be present only)

      This commit address the problem by introducing two conditional tasks:
        - task which depends on a `thumbor_version` variable being present, which ensures specific version will be present
        - task which depends on a `thumbor_version` variable being absent, which requires latest version on every run